### PR TITLE
Debugging

### DIFF
--- a/libsodium.c
+++ b/libsodium.c
@@ -1,4 +1,3 @@
-
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -493,6 +492,7 @@ PHP_FUNCTION(crypto_box)
     unsigned char *out;
     unsigned char *publickey;
     unsigned char *secretkey;
+    unsigned char *debug;
     int            keypair_len;
     int            msg_len;
     int            msg_zeroed_len;
@@ -505,11 +505,15 @@ PHP_FUNCTION(crypto_box)
         return;
     }
     if (nonce_len != crypto_box_NONCEBYTES) {
-        zend_error(E_ERROR,
+        sprintf(debug, "%d != %d\n", nonce_len, crypto_box_NONCEBYTES);
+        zend_error(E_NOTICE, debug);
+        zend_error(E_NOTICE,
                    "crypto_box(): nonce size should be CRYPTO_BOX_NONCEBYTES long");
     }
     if (keypair_len != crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES) {
-        zend_error(E_ERROR,
+        sprintf(debug, "%d != %d\n", keypair_len, crypto_box_SECRETKEYBYTES + crypto_box_PUBLICKEYBYTES);
+        zend_error(E_NOTICE, debug);
+        zend_error(E_NOTICE,
                    "crypto_box(): keypair size should be CRYPTO_BOX_KEYPAIRBYTES long");
     }
     secretkey = keypair;


### PR DESCRIPTION
This should reproduce the fatal errors, only now they're notices (just for illustrative purposes).

``` html
<?php
header("Content-Type: text/plain;charset=UTF-8");
// TESTING
echo CRYPTO_BOX_NONCEBYTES."\n";
$message = 'Hello world';
$nonce = randombytes_buf(CRYPTO_BOX_NONCEBYTES);
$Alice = crypto_box_keypair();
$Bob = crypto_box_keypair();

$alice = [ crypto_box_secretkey($Alice), crypto_box_publickey($Alice) ];
$bob = [ crypto_box_secretkey($Bob), crypto_box_publickey($Bob) ];

$keypair = crypto_box_keypair_from_secretkey_and_publickey
            ($alice[0], $bob[1]);

$ciphertext = crypto_box($message, $keypair, $nonce);
```

Output:

``` 24
<br />
<b>Notice</b>:  64 != 24
 in <b>/var/www/website/includes/index.php</b> on line <b>16</b><br />
<br />
<b>Notice</b>:  crypto_box(): nonce size should be CRYPTO_BOX_NONCEBYTES long in <b>/var/www/website/includes/index.php</b> on line <b>16</b><br />
<br />
<b>Notice</b>:  24 != 64
 in <b>/var/www/website/includes/index.php</b> on line <b>16</b><br />
```
