### PR TITLE
Cleanup for 0.1.1

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -27,7 +27,7 @@ if test "$PHP_LIBSODIUM" != "no"; then
   PHP_ADD_INCLUDE($LIBSODIUM_DIR/include)
 
   LIBNAME=sodium
-  LIBSYMBOL=sodium_init
+  LIBSYMBOL=crypto_pwhash_scryptsalsa208sha256
 
   PHP_CHECK_LIBRARY($LIBNAME,$LIBSYMBOL,
   [


### PR DESCRIPTION
Documentation claims Requires libsodium >= 0.5.0 and PHP >= 5.2.0
but doesn't build with 0.5.0, because of missing crypto_pwhash_scryptsalsa208sha256\* functions.

Other solution will be to add condition around those functions. Don't know you want to allow build with older versions.

FYI, http://rpms.famillecollet.com/rpmphp/zoom.php?rpm=libsodium  (so 0.4.5 support will be nice)

With 0.4.5:

```
libsodium.c:379:5: warning: implicit declaration of function 'crypto_secretbox_easy' [-Wimplicit-function-declaration]
libsodium.c:421:5: warning: implicit declaration of function 'crypto_secretbox_open_easy' [-Wimplicit-function-declaration]
libsodium.c:627:5: warning: implicit declaration of function 'crypto_box_easy' [-Wimplicit-function-declaration]
libsodium.c:673:5: warning: implicit declaration of function 'crypto_box_open_easy' [-Wimplicit-function-declaration]
libsodium.c:929:9: warning: implicit declaration of function 'crypto_pwhash_scryptsalsa208sha256' [-Wimplicit-function-declaration]
libsodium.c:969:9: warning: implicit declaration of function 'crypto_pwhash_scryptsalsa208sha256_str' [-Wimplicit-function-declaration]
libsodium.c:1000:9: warning: implicit declaration of function 'crypto_pwhash_scryptsalsa208sha256_str_verify' [-Wimplicit-function-declaration]
```
