### PR TITLE
Fix compilation with VC9 and VC11

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,2 +1,2 @@
 ;; libsodium
-Frank Denis [jedisct1] <jedisct1@php.net> (lead)
+Frank Denis [jedisct1@php.net] (lead)


### PR DESCRIPTION
A '<' in the credits breaks compilation on Windows. After this change php_libsodium.dll compiles fine on Windows (PHP 5.3, 5.4, 5.5, 5.6, 7.0 / x86 & x64). I did not run the tests yet.