### PR TITLE
Fix error message of crypto_aead_chacha20poly1305_{encrypt,decrypt}

### DIFF
--- a/libsodium.c
+++ b/libsodium.c
@@ -1412,7 +1412,7 @@ PHP_FUNCTION(crypto_aead_chacha20poly1305_encrypt)
         zend_error(E_ERROR,
                    "crypto_aead_chacha20poly1305_encrypt(): "
                    "secret key size should be "
-                   "CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES bytes");
+                   "CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES bytes");
     }
     if (INT_MAX - msg_len <= crypto_aead_chacha20poly1305_ABYTES) {
         zend_error(E_ERROR, "arithmetic overflow");
@@ -1466,7 +1466,7 @@ PHP_FUNCTION(crypto_aead_chacha20poly1305_decrypt)
         zend_error(E_ERROR,
                    "crypto_aead_chacha20poly1305_decrypt(): "
                    "secret key size should be "
-                   "CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES bytes");
+                   "CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES bytes");
     }
     msg_len = ciphertext_len;
     if (msg_len >= INT_MAX) {


### PR DESCRIPTION
We need a `CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES` bytes long key.