### PR TITLE
fix build with old libsodium

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -38,7 +38,13 @@ if test "$PHP_LIBSODIUM" != "no"; then
   ],[
     -L$LIBSODIUM_DIR/$PHP_LIBDIR
   ])
-  
+  PHP_CHECK_LIBRARY($LIBNAME,crypto_aead_aes256gcm_encrypt,
+  [
+    AC_DEFINE(HAVE_CRYPTO_AEAD_AES256GCM,1,[ ])
+  ],[],[
+    -L$LIBSODIUM_DIR/$PHP_LIBDIR
+  ])
+
   PHP_SUBST(LIBSODIUM_SHARED_LIBADD)
 
   PHP_NEW_EXTENSION(libsodium, libsodium.c, $ext_shared)

--- a/libsodium.c
+++ b/libsodium.c
@@ -2033,6 +2033,8 @@ PHP_FUNCTION(crypto_sign_ed25519_pk_to_curve25519)
     RETURN_STR(ecdhkey);
 }
 
+#if SODIUM_LIBRARY_VERSION_MAJOR > 7 || \
+    (SODIUM_LIBRARY_VERSION_MAJOR == 7 && SODIUM_LIBRARY_VERSION_MINOR >= 6)
 PHP_FUNCTION(sodium_compare)
 {
     char      *buf1;
@@ -2054,3 +2056,4 @@ PHP_FUNCTION(sodium_compare)
                                    (const unsigned char *) buf2, (size_t) len1));
     }
 }
+#endif

--- a/libsodium.c
+++ b/libsodium.c
@@ -148,7 +148,7 @@ ZEND_END_ARG_INFO()
 # define PHP_FE_END { NULL, NULL, NULL }
 #endif
 
-#if defined(crypto_aead_aes256gcm_KEYBYTES) && \
+#if defined(HAVE_CRYPTO_AEAD_AES256GCM) && defined(crypto_aead_aes256gcm_KEYBYTES) && \
     (defined(__amd64) || defined(__amd64__) || defined(__x86_64__) || defined(__i386__) || \
      defined(_M_AMD64) || defined(_M_IX86))
 # define HAVE_AESGCM 1

--- a/tests/crypto_aead.phpt
+++ b/tests/crypto_aead.phpt
@@ -1,7 +1,10 @@
 --TEST--
 Check for libsodium AEAD
 --SKIPIF--
-<?php if (!extension_loaded("libsodium")) print "skip"; ?>
+<?php
+if (!extension_loaded("libsodium")) print "skip extension not loaded";
+if (!defined('Sodium\CRYPTO_AEAD_AES256GCM_NPUBBYTES')) print "skip libsodium without AESGCM";
+?>
 --FILE--
 <?php
 $msg = \Sodium\randombytes_buf(\Sodium\randombytes_uniform(1000));


### PR DESCRIPTION
With libsodium 1.0.3

     PHP Warning:  PHP Startup: Unable to load dynamic library '/builddir/build/BUILDROOT/php-pecl-libsodium-1.0.1-1.el7.remi.5.4.x86_64/usr/lib64/php/modules/libsodium.so' - /builddir/build/BUILDROOT/php-pecl-libsodium-1.0.1-1.el7.remi.5.4.x86_64/usr/lib64/php/modules/libsodium.so: undefined symbol: sodium_compare in Unknown on line 0
