### PR TITLE
fix test

### DIFF
--- a/tests/crypto_auth.phpt
+++ b/tests/crypto_auth.phpt
@@ -18,13 +18,9 @@ var_dump(\Sodium\crypto_auth_verify($mac, $badmsg, $key));
 
 // Let's flip a bit pseudo-randomly
 $badmsg = $msg;
-$badmsg[mt_rand(0, 999)] = \chr(
-    \ord($msg[0]) ^ (
-        // Mask out higher bits (thus 256 => 0)
-        0xFF & (
-            // 1, 2, 4, 8, 16, 32, 64, 128, 256
-            1 << mt_rand(0, 8)
-        )
+$badmsg[$i=mt_rand(0, 999)] = \chr(
+    \ord($msg[$i]) ^ (
+        1 << mt_rand(0, 7)
     )
 );
 
@@ -32,7 +28,7 @@ var_dump(\Sodium\crypto_auth_verify($mac, $badmsg, $key));
 
 // Now let's change a bit in the MAC
 $badmac = $mac;
-$badmac[0] = \chr(\ord($badmsg[0]) ^ 0x80);
+$badmac[0] = \chr(\ord($badmac[0]) ^ 0x80);
 var_dump(\Sodium\crypto_auth_verify($badmac, $msg, $key));
 ?>
 --EXPECT--


### PR DESCRIPTION
This test give erratic result, see https://kojipkgs.fedoraproject.org//work/tasks/6600/12016600/build.log
 
1/ the byte should be retrieved/stored at the same position ($i added)

2/ bad change

    mt_rand(0, 8) => can give 8
    1 << 8 = 256
    0xFF & 256 = 0
    any char ^ 0 = same char

3/ obvious typo

running it ~200 time without any failure.