### PR TITLE
make tests pass under php-5.3

### DIFF
--- a/tests/utils.phpt
+++ b/tests/utils.phpt
@@ -16,19 +16,19 @@ $b = 'string';
 $c = 'string';
 var_dump(!\Sodium\memcmp($b, $c));
 var_dump(!\Sodium\memcmp($b, 'String'));
-$v = hex2bin('FFFF800102030405060708');
+$v = "\xFF\xFF\x80\x01\x02\x03\x04\x05\x06\x07\x08";
 \Sodium\increment($v);
 var_dump(bin2hex($v));
 
-$w = hex2bin('0102030405060708FAFBFC');
+$w = "\01\x02\x03\x04\x05\x06\x07\x08\xFA\xFB\xFC";
 \Sodium\add($v, $w);
 var_dump(bin2hex($v));
 
 if (\Sodium\library_version_major() > 7 ||
     (\Sodium\library_version_major() == 7 &&
      \Sodium\library_version_minor() >= 6)) {
-    $v_1 = hex2bin('0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F');
-    $v_2 = hex2bin('0202030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F');
+    $v_1 = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F";
+    $v_2 = "\x02\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F";
     var_dump(\Sodium\compare($v_1, $v_2));
     \Sodium\increment($v_1);
     var_dump(\Sodium\compare($v_1, $v_2));
@@ -40,7 +40,7 @@ if (\Sodium\library_version_major() > 7 ||
 }
 $str = 'stdClass';
 \Sodium\memzero($str);
-$obj = (object)['foo' => 'bar'];
+$obj = (object)array('foo' => 'bar');
 var_dump($obj);
 ?>
 --EXPECT--


### PR DESCRIPTION
as this was the only test that failed under php 5.3 and the fixes were trivial, decided to "upstream" it

adopted patch from
https://github.com/pld-linux/php-pecl-libsodium/commit/f3d673b7a61aa19af8ea2675395a03f6a13203af (it's for 1.0.2)