### PR TITLE
Fixing --with-libsodium documentation.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -2,7 +2,7 @@ dnl $Id$
 dnl config.m4 for extension libsodium
 
 PHP_ARG_WITH(libsodium, for libsodium support,
-[  --with-libsodium             Include libsodium support])
+[  --with-libsodium[=DIR]             Include libsodium support])
 
 if test "$PHP_LIBSODIUM" != "no"; then
   SEARCH_PATH="/usr/local /usr"     # you might want to change this


### PR DESCRIPTION
This addresses some confusion I had installing the extension with MacPorts. (#103)