### PR TITLE
Convert errors to exceptions; move to supporting PHP 7.0+ only (for v2 branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 php:
  - "7.0"
- - "5.6"
- - "5.5"
- - "5.4"
- - "5.3"
+ - "7.1"
+ - "nightly"
 
 matrix:
  fast_finish: true

--- a/libsodium.c
+++ b/libsodium.c
@@ -472,6 +472,7 @@ PHP_FUNCTION(sodium_increment)
         zend_throw_exception(zend_ce_exception, "increment(): a PHP string is required", 0);
         return;
     }
+    SEPARATE_STRING(zval_zv);
     val = (unsigned char *) Z_STRVAL(*val_zv);
     val_len = Z_STRLEN(*val_zv);
     c = 1U << 8;
@@ -505,6 +506,7 @@ PHP_FUNCTION(sodium_add)
         zend_throw_exception(zend_ce_exception, "add(): PHP strings are required", 0);
         return;
     }
+    SEPARATE_STRING(zval_zv);
     val = (unsigned char *) Z_STRVAL(*val_zv);
     val_len = Z_STRLEN(*val_zv);
     if (val_len != addv_len) {
@@ -1522,7 +1524,7 @@ PHP_FUNCTION(sodium_crypto_sign_verify_detached)
         return;
     }
     if (signature_len != crypto_sign_BYTES) {
-        zend_throw_exception(zend_ce_exception, 
+        zend_throw_exception(zend_ce_exception,
                    "crypto_sign_verify_detached(): signature size should be "
                    "CRYPTO_SIGN_BYTES bytes",
                    0);

--- a/libsodium.c
+++ b/libsodium.c
@@ -472,7 +472,7 @@ PHP_FUNCTION(sodium_increment)
         zend_throw_exception(zend_ce_exception, "increment(): a PHP string is required", 0);
         return;
     }
-    SEPARATE_STRING(zval_zv);
+    SEPARATE_STRING(val_zv);
     val = (unsigned char *) Z_STRVAL(*val_zv);
     val_len = Z_STRLEN(*val_zv);
     c = 1U << 8;

--- a/libsodium.c
+++ b/libsodium.c
@@ -472,7 +472,6 @@ PHP_FUNCTION(sodium_increment)
         zend_throw_exception(zend_ce_exception, "increment(): a PHP string is required", 0);
         return;
     }
-    SEPARATE_STRING(val_zv);
     val = (unsigned char *) Z_STRVAL(*val_zv);
     val_len = Z_STRLEN(*val_zv);
     c = 1U << 8;
@@ -506,7 +505,6 @@ PHP_FUNCTION(sodium_add)
         zend_throw_exception(zend_ce_exception, "add(): PHP strings are required", 0);
         return;
     }
-    SEPARATE_STRING(val_zv);
     val = (unsigned char *) Z_STRVAL(*val_zv);
     val_len = Z_STRLEN(*val_zv);
     if (val_len != addv_len) {

--- a/libsodium.c
+++ b/libsodium.c
@@ -506,7 +506,7 @@ PHP_FUNCTION(sodium_add)
         zend_throw_exception(zend_ce_exception, "add(): PHP strings are required", 0);
         return;
     }
-    SEPARATE_STRING(zval_zv);
+    SEPARATE_STRING(val_zv);
     val = (unsigned char *) Z_STRVAL(*val_zv);
     val_len = Z_STRLEN(*val_zv);
     if (val_len != addv_len) {

--- a/tests/crypto_aead.phpt
+++ b/tests/crypto_aead.phpt
@@ -31,6 +31,13 @@ if (sodium_library_version_major() > 7 ||
     var_dump($ciphertext !== $msg);
     var_dump($msg === $msg2);
     var_dump(sodium_crypto_aead_chacha20poly1305_ietf_decrypt($ciphertext, 'x' . $ad, $nonce, $key));
+    try {
+        // Switched order
+        $msg2 = sodium_crypto_aead_chacha20poly1305_ietf_decrypt($ciphertext, $ad, $key, $nonce);
+        var_dump(false);
+    } catch (Exception $ex) {
+        var_dump(true);
+    }
 } else {
     var_dump(true);
     var_dump(true);
@@ -51,7 +58,7 @@ if (sodium_crypto_aead_aes256gcm_is_available()) {
 } else {
     var_dump(true);
     var_dump(true);
-    var_dump(false);    
+    var_dump(false);
 }
 ?>
 --EXPECT--
@@ -61,6 +68,7 @@ bool(false)
 bool(true)
 bool(true)
 bool(false)
+bool(true)
 bool(true)
 bool(true)
 bool(false)

--- a/tests/crypto_auth.phpt
+++ b/tests/crypto_auth.phpt
@@ -11,6 +11,14 @@ $mac = sodium_crypto_auth($msg, $key);
 // This should validate
 var_dump(sodium_crypto_auth_verify($mac, $msg, $key));
 
+$bad_key = sodium_randombytes_buf(SODIUM_CRYPTO_AUTH_KEYBYTES - 1);
+try {
+    $mac = sodium_crypto_auth($msg, $bad_key);
+    echo 'Fail!', PHP_EOL;
+} catch (Exception $ex) {
+  echo $ex->getMessage(), PHP_EOL;
+}
+
 // Flip the first bit
 $badmsg = $msg;
 $badmsg[0] = \chr(\ord($badmsg[0]) ^ 0x80);
@@ -33,6 +41,7 @@ var_dump(sodium_crypto_auth_verify($badmac, $msg, $key));
 ?>
 --EXPECT--
 bool(true)
+crypto_auth(): key must be CRYPTO_AUTH_KEYBYTES bytes
 bool(false)
 bool(false)
 bool(false)

--- a/tests/crypto_box.phpt
+++ b/tests/crypto_box.phpt
@@ -42,6 +42,16 @@ $ciphertext = sodium_crypto_box(
     $alice_to_bob_kp
 );
 
+try {
+  $ciphertext = sodium_crypto_box(
+      $msg,
+      $message_nonce,
+      substr($alice_to_bob_kp, 1)
+  );
+} catch (Exception $ex) {
+    echo $ex->getMessage(), PHP_EOL;
+}
+
 sodium_memzero($alice_box_kp);
 sodium_memzero($bob_box_kp);
 
@@ -132,6 +142,7 @@ bool(true)
 bool(true)
 bool(true)
 bool(true)
+crypto_box(): keypair size should be CRYPTO_BOX_KEYPAIRBYTES bytes
 bool(true)
 string(17) "Hi, this is Alice"
 string(21) "Hi Alice! This is Bob"

--- a/tests/crypto_generichash.phpt
+++ b/tests/crypto_generichash.phpt
@@ -40,6 +40,11 @@ $act = bin2hex(
 );
 var_dump($act);
 var_dump($exp === $act);
+try {
+    $hash = sodium_crypto_generichash('test', '', 128);
+} catch (Exception $ex) {
+    var_dump(true);
+}
 ?>
 --EXPECT--
 string(64) "96a7ed8861db0abc006f473f9e64687875f3d9df8e723adae9f53a02b2aec378"
@@ -52,4 +57,5 @@ string(64) "ba03e32a94ece425a77b350f029e0a3d37e6383158aa7cefa2b1b9470a7fcb7a"
 string(128) "8ccd640462e7380010c5722d7f3c2354781d1360430197ff233509c27353fd2597c8d689bfe769467056a0655b3faba6af4e4ade248558f7c53538c4d5b94806"
 string(128) "9ef702f51114c9dc2cc7521746e8beebe0a3ca9bb29ec729e16682ca982e7f69ff70235a46659a9a6c28f92fbd990288301b9a6b5517f1f2ba6518074af19a5a"
 string(128) "9ef702f51114c9dc2cc7521746e8beebe0a3ca9bb29ec729e16682ca982e7f69ff70235a46659a9a6c28f92fbd990288301b9a6b5517f1f2ba6518074af19a5a"
+bool(true)
 bool(true)

--- a/tests/crypto_kx.phpt
+++ b/tests/crypto_kx.phpt
@@ -20,7 +20,18 @@ $shared_key_computed_by_server =
 
 var_dump(sodium_bin2hex($shared_key_computed_by_client));
 var_dump(sodium_bin2hex($shared_key_computed_by_server));
+try {
+    sodium_crypto_kx(
+        substr($client_secretkey, 1),
+        $server_publickey,
+        $client_publickey,
+        $server_publickey
+    );
+} catch (Exception $ex) {
+    var_dump(true);
+}
 ?>
 --EXPECT--
 string(64) "509a1580c2ee30c565317e29e0fea0b1c232e0ef3a7871d91dc64814b19a3bd2"
 string(64) "509a1580c2ee30c565317e29e0fea0b1c232e0ef3a7871d91dc64814b19a3bd2"
+bool(true)

--- a/tests/crypto_scalarmult.phpt
+++ b/tests/crypto_scalarmult.phpt
@@ -9,6 +9,12 @@ $p = sodium_hex2bin("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9
 $q = sodium_crypto_scalarmult($n, $p);
 
 var_dump(sodium_bin2hex($q));
+try {
+    sodium_crypto_scalarmult(substr($n, 1), $p);
+} catch (Exception $ex) {
+    var_dump(true);
+}
 ?>
 --EXPECT--
 string(64) "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742"
+bool(true)

--- a/tests/crypto_secretbox.phpt
+++ b/tests/crypto_secretbox.phpt
@@ -13,7 +13,14 @@ var_dump(bin2hex($x));
 $y = sodium_crypto_secretbox_open("\0" . $a, $nonce, $key);
 var_dump($y);
 
+try {
+    sodium_crypto_secretbox('test', substr($nonce, 1), $key);
+} catch (Exception $ex) {
+    var_dump(true);
+}
+
 ?>
 --EXPECT--
 string(8) "74657374"
 bool(false)
+bool(true)

--- a/tests/crypto_shorthash.phpt
+++ b/tests/crypto_shorthash.phpt
@@ -14,8 +14,15 @@ echo bin2hex($h2) . "\n";
 $m2 = 'msg';
 $h3 = sodium_crypto_shorthash($m2, $k2);
 echo bin2hex($h3) . "\n";
+
+try {
+    sodium_crypto_shorthash($m1, $k1 . $k2);
+} catch (Exception $ex) {
+    var_dump(true);
+}
 ?>
 --EXPECT--
 e0ad6fdbf8b9a191
 c667b37af201a2d9
 d27fa3fc70b45b72
+bool(true)

--- a/tests/crypto_sign.phpt
+++ b/tests/crypto_sign.phpt
@@ -56,6 +56,12 @@ var_dump(sodium_memcmp($calc_pubkey, $alice_publickey) === 0);
 $ed25519key = sodium_hex2bin("55b62f664bf1c359f58a6b91b89556f97284273510573055b9237d17f5a20564607f0626f49e63c2c8f814ed6d955bf8b005b33fd5fd56eaca93073d8eb99165");
 $curve25519key = sodium_crypto_sign_ed25519_sk_to_curve25519($ed25519key);
 var_dump($curve25519key === sodium_hex2bin("381b2be5e3d38820deb1243fb58b4be654da30dd3ccde492cb88f937eb489363"));
+
+try {
+    sodium_crypto_sign($msg, substr($alice_secretkey, 1));
+} catch (Exception $ex) {
+    var_dump(true);
+}
 ?>
 --EXPECT--
 bool(true)
@@ -70,5 +76,6 @@ bool(true)
 bool(true)
 bool(true)
 bool(false)
+bool(true)
 bool(true)
 bool(true)

--- a/tests/crypto_stream.phpt
+++ b/tests/crypto_stream.phpt
@@ -32,9 +32,16 @@ $stream6 = sodium_crypto_stream_xor($stream5, $nonce, $key);
 
 var_dump($stream6 === $stream);
 
+try {
+    sodium_crypto_stream($len, substr($nonce, 1), $key);
+} catch (Exception $ex) {
+    var_dump(true);
+}
+
 ?>
 --EXPECT--
 int(100)
+bool(true)
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
Seeing if Travis CI passes it first. I probably need to update the tests to reflect this API change.

Closes #93, #107.