### PR TITLE
Make crypto_aead test never call random_bytes(0)

### DIFF
--- a/tests/crypto_aead.phpt
+++ b/tests/crypto_aead.phpt
@@ -9,10 +9,10 @@ if (!defined('SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES')) print "skip libsodium wi
 <?php
 echo "aead_chacha20poly1305:\n";
 
-$msg = random_bytes(random_int(0, 1000));
+$msg = random_bytes(random_int(1, 1000));
 $nonce = random_bytes(SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_NPUBBYTES);
 $key = random_bytes(SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES);
-$ad = random_bytes(random_int(0, 1000));
+$ad = random_bytes(random_int(1, 1000));
 
 $ciphertext = sodium_crypto_aead_chacha20poly1305_encrypt($msg, $ad, $nonce, $key);
 $msg2 = sodium_crypto_aead_chacha20poly1305_decrypt($ciphertext, $ad, $nonce, $key);
@@ -32,10 +32,10 @@ echo "aead_chacha20poly1305_ietf:\n";
 if (SODIUM_LIBRARY_MAJOR_VERSION > 7 ||
 	(SODIUM_LIBRARY_MAJOR_VERSION == 7 &&
 	 SODIUM_LIBRARY_MINOR_VERSION >= 6)) {
-	$msg = random_bytes(random_int(0, 1000));
+	$msg = random_bytes(random_int(1, 1000));
 	$nonce = random_bytes(SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES);
 	$key = random_bytes(SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_KEYBYTES);
-	$ad = random_bytes(random_int(0, 1000));
+	$ad = random_bytes(random_int(1, 1000));
 
 	$ciphertext = sodium_crypto_aead_chacha20poly1305_ietf_encrypt($msg, $ad, $nonce, $key);
 	$msg2 = sodium_crypto_aead_chacha20poly1305_ietf_decrypt($ciphertext, $ad, $nonce, $key);
@@ -61,10 +61,10 @@ echo "aead_xchacha20poly1305_ietf:\n";
 if (SODIUM_LIBRARY_MAJOR_VERSION > 9 ||
 	(SODIUM_LIBRARY_MAJOR_VERSION == 9 &&
 	 SODIUM_LIBRARY_MINOR_VERSION >= 4)) {
-	$msg = random_bytes(random_int(0, 1000));
+	$msg = random_bytes(random_int(1, 1000));
 	$nonce = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
 	$key = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES);
-	$ad = random_bytes(random_int(0, 1000));
+	$ad = random_bytes(random_int(1, 1000));
 
 	$ciphertext = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt($msg, $ad, $nonce, $key);
 	$msg2 = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($ciphertext, $ad, $nonce, $key);
@@ -87,10 +87,10 @@ if (SODIUM_LIBRARY_MAJOR_VERSION > 9 ||
 
 echo "aead_aes256gcm:\n";
 
-$msg = random_bytes(random_int(0, 1000));
+$msg = random_bytes(random_int(1, 1000));
 $nonce = random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES);
 $key = random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES);
-$ad = random_bytes(random_int(0, 1000));
+$ad = random_bytes(random_int(1, 1000));
 
 if (sodium_crypto_aead_aes256gcm_is_available()) {
 	$ciphertext = sodium_crypto_aead_aes256gcm_encrypt($msg, $ad, $nonce, $key);


### PR DESCRIPTION
If random_int(0, x) happens to return 0, test calls random_bytes(0) which is a fatal error.

Thanks to @markw65 - found by HHVM testing.