### PR TITLE
Make crypto_hex test never call random_bytes(0)

### DIFF
--- a/tests/crypto_hex.phpt
+++ b/tests/crypto_hex.phpt
@@ -4,7 +4,7 @@ Check for libsodium bin2hex
 <?php if (!extension_loaded("libsodium")) print "skip"; ?>
 --FILE--
 <?php
-$bin = random_bytes(random_int(0, 1000));
+$bin = random_bytes(random_int(1, 1000));
 $hex = sodium_bin2hex($bin);
 $phphex = bin2hex($bin);
 var_dump(strcasecmp($hex, $phphex));


### PR DESCRIPTION
random_int() occasionally returns 0, making random_bytes() fatal.

Thanks to @markw65 - found with HHVM testing.