### PR TITLE
drop uneeded files from pecl archive

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,16 +28,11 @@ No code change. This release was made to ensure that the stable channel installs
     <dir name="/">
       <file role="doc" name="README.md"/>
       <file role="doc" name="LICENSE"/>
-      <file role="src" name="acinclude.m4"/>
-      <file role="src" name="aclocal.m4"/>
       <file role="src" name="config.h"/>
       <file role="src" name="config.m4"/>
       <file role="src" name="config.w32"/>
       <file role="src" name="libsodium.c"/>
       <file role="src" name="php_libsodium.h"/>
-      <dir name="build">
-        <file role="src" name="libtool.m4"/>
-      </dir>
       <dir name="tests">
         <file role="test" name="crypto_aead.phpt"/>
         <file role="test" name="crypto_auth.phpt"/>


### PR DESCRIPTION
These files are generated during phpize phase, copied from the PHP build directory.
