### PR TITLE
Use the new flag name in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
  - phpize
- - ./configure --with-libsodium
+ - ./configure --with-sodium
  - make clean
  - make
  - env NO_INTERACTION=1 make test


### PR DESCRIPTION
Example travis error: https://travis-ci.org/jedisct1/libsodium-php/jobs/310061573#L1085
Introduced after: https://github.com/jedisct1/libsodium-php/commit/0ddcaf83f611537902e52f73f9868937ab247236