### PR TITLE
Proposed fix for Travis CI on PHP 7.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: SKIP_INSTALL=0
     - php: "7.2"
       env: SKIP_INSTALL=1
+    - php: "7.3"
+      env: SKIP_INSTALL=1
     - php: "nightly"
       env: SKIP_INSTALL=1
     - php: "master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: php
-php:
- - "7.0"
- - "7.1"
- - "7.2"
- - "7.3"
- - "nightly"
-
 matrix:
- fast_finish: true
+  fast_finish: true
+  include:
+    - php: "7.0"
+      env: SKIP_INSTALL=0
+    - php: "7.1"
+      env: SKIP_INSTALL=0
+           CHECK_MBSTRING=1
+    - php: "7.2"
+      env: SKIP_INSTALL=1
+    - php: "nightly"
+      env: SKIP_INSTALL=1
+    - php: "master"
+      env: SKIP_INSTALL=1
+  allow_failures:
+    - php: "nightly"
+    - php: "master"
 
 os:
  - linux
@@ -24,8 +32,8 @@ before_script:
  - rm -fr libsodium
 
 script:
- - phpize
- - ./configure --with-sodium
- - make clean
- - make
+ - if [[ $SKIP_INSTALl -eq 0 ]]; phpize; endif
+ - if [[ $SKIP_INSTALl -eq 0 ]]; ./configure --with-sodium; endif
+ - if [[ $SKIP_INSTALl -eq 0 ]]; make clean; endif
+ - if [[ $SKIP_INSTALl -eq 0 ]]; make; endif
  - env NO_INTERACTION=1 make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       env: SKIP_INSTALL=0
     - php: "7.1"
       env: SKIP_INSTALL=0
-           CHECK_MBSTRING=1
     - php: "7.2"
       env: SKIP_INSTALL=1
     - php: "nightly"


### PR DESCRIPTION
Should remove `PHP Warning:  Module 'sodium' already loaded in Unknown on line 0` from test script outputs which cause false negatives.