### PR TITLE
Add version constant following the package name for Pickle installation

### DIFF
--- a/php_libsodium.h
+++ b/php_libsodium.h
@@ -5,7 +5,8 @@
 extern zend_module_entry sodium_module_entry;
 #define phpext_sodium_ptr &sodium_module_entry
 
-#define PHP_SODIUM_VERSION "2.0.22"
+#define PHP_LIBSODIUM_VERSION "2.0.22"
+#define PHP_SODIUM_VERSION PHP_LIBSODIUM_VERSION
 
 #ifdef PHP_WIN32
 # define PHP_SODIUM_API __declspec(dllexport)


### PR DESCRIPTION
As the package is named `libsodium` the Pickle extension installer looks for a constant called `PHP_LIBSODIUM_VERSION` which doesn't exist and Pickle fails to install with:
```
In Version.php line 91:
    Couldn't parse or find the version defined in the PHP_LIBSODIUM_VERSION macro
```

I assume the existing constant is needed for backwards compatibility. I added the new version first as Pickle is only capable of parsing constant strings, not references to other constants, so doing `PHP_LIBSODIUM_VERSION = PHP_SODIUM_VERSION` wouldn't work. 